### PR TITLE
Enemy spawning controlled by map

### DIFF
--- a/my_game.py
+++ b/my_game.py
@@ -123,12 +123,6 @@ class GameView(arcade.View):
 
         self.sample_enemy.go_to_position((100, 100))
 
-        # Track the current state of what keys are pressed
-        self.left_pressed = False
-        self.right_pressed = False
-        self.up_pressed = False
-        self.down_pressed = False
-
         # Get list of joysticks
         joysticks = arcade.get_joysticks()
 

--- a/my_game.py
+++ b/my_game.py
@@ -8,6 +8,7 @@ Artwork from https://kenney.nl/assets/space-shooter-redux
 """
 
 import arcade
+import random
 from pyglet.math import Vec2
 
 # Import sprites from local file my_sprites.py
@@ -106,22 +107,33 @@ class GameView(arcade.View):
             scale=SCALING,
         )
 
-        # create a sample enemy
-        self.sample_enemy = Enemy(
-            position=(200, 200),
-            impassables=self.tilemap.sprite_lists["impassable"],
-            grid_size=int(self.tilemap.tile_width),
-            window=self.window,
-            scale=SCALING
-        )
-        
+        # Change all tiles in the 'enemies' layer to Enemies
+        for enemy_index, enemy_position in enumerate([ s.position for s in self.tilemap.sprite_lists["enemies"]]):
+            # Create the enemy
+            e = Enemy(
+                position=enemy_position,
+                impassables=self.tilemap.sprite_lists["impassable"],
+                grid_size=int(self.tilemap.tile_width),
+                window=self.window,
+                scale=SCALING
+            )
+
+            # Go to position of random passable tile
+            # FIXME: Often, no path will be found. Why is that??
+            # e.go_to_position(random.choice(self.tilemap.sprite_lists["background"]).position)
+            # Go to the player's position
+            e.go_to_position(self.player.position)
+
+            # Replace the spawn point with the new enemy
+            self.tilemap.sprite_lists["enemies"][enemy_index] = e
+
+
         # Register player and walls with physics engine
         self.physics_engine =  arcade.PhysicsEngineSimple(
             player_sprite=self.player,
             walls = self.tilemap.sprite_lists["impassable"]
         )
 
-        self.sample_enemy.go_to_position((100, 100))
 
         # Get list of joysticks
         joysticks = arcade.get_joysticks()
@@ -188,8 +200,6 @@ class GameView(arcade.View):
         # Draw the player sprite
         self.player.draw(pixelated=DRAW_PIXELATED)
 
-        self.sample_enemy.draw(pixelated=DRAW_PIXELATED)
-
     def on_update(self, delta_time):
         """
         Movement and game logic
@@ -202,7 +212,8 @@ class GameView(arcade.View):
         # Return all sprites involved in collissions
         colliding_sprites = self.physics_engine.update()
 
-        self.sample_enemy.on_update()
+        # Update the enemies
+        self.tilemap.sprite_lists["enemies"].on_update()
 
         # Update the player shots
         self.player_shot_list.on_update(delta_time)

--- a/my_game.py
+++ b/my_game.py
@@ -294,7 +294,7 @@ class IntroView(arcade.View):
             self.window.width / 2,
             self.window.height / 2,
             arcade.color.WHITE,
-            font_size=50,
+            font_size=20,
             font_name=MAIN_FONT_NAME,
             anchor_x="center",
             bold=True

--- a/my_game.py
+++ b/my_game.py
@@ -108,16 +108,10 @@ class GameView(arcade.View):
 
         # create a sample enemy
         self.sample_enemy = Enemy(
-            filename="images/tiny_dungeon/Tiles/tile_0087.png",
-            center_pos=(200, 200),
-            max_hp=10,
-            speed=1,
+            position=(200, 200),
             impassables=self.tilemap.sprite_lists["impassable"],
             grid_size=int(self.tilemap.tile_width),
-            boundary_left=0,
-            boundary_right=SCREEN_WIDTH,
-            boundary_bottom=0,
-            boundary_top=SCREEN_HEIGHT,
+            window=self.window,
             scale=SCALING
         )
         

--- a/my_sprites.py
+++ b/my_sprites.py
@@ -6,29 +6,28 @@ class Enemy(arcade.Sprite):
     parent class for all enemies in the game. Features include pathfinding, hp management and movement
 
     :param filename: path to the file used as graphics for the sprite.
-    :param center_pos: tuple containing the x and y coordinate to create the sprite at.
+    :param position: tuple containing the x and y coordinate to create the sprite at.
     :param max_hp: the max hp for the enemy. Also determines starting hp.
     :param speed: the movement speed for the sprite in px/update.
     :param scale: the size multiplier for the graphics/hitbox of the sprite.
     """
 
     def __init__(
-            self, filename: str,
-            center_pos: tuple[float, float],
-            max_hp: int, speed: float,
+            self,
+            position: tuple[float, float],
             impassables: arcade.SpriteList,
+            window: arcade.Window,
             grid_size: int,
-            boundary_left: int,
-            boundary_right: int,
-            boundary_bottom: int,
-            boundary_top: int,
-            scale=1.0):
+            filename: str = "images/tiny_dungeon/Tiles/tile_0087.png",
+            max_hp: int = 10,
+            speed: int = 1,
+            scale: float = 1.0):
 
         super().__init__(
             filename=filename,
             scale=scale,
-            center_x=center_pos[0],
-            center_y=center_pos[1]
+            center_x=position[0],
+            center_y=position[1]
         )
 
         # hp
@@ -46,10 +45,10 @@ class Enemy(arcade.Sprite):
             moving_sprite=self,
             blocking_sprites=impassables,
             grid_size=grid_size,
-            left=boundary_left,
-            right=boundary_right,
-            bottom=boundary_bottom,
-            top=boundary_top
+            left=0,
+            right=window.width,
+            bottom=0,
+            top=window.height
         )
 
     @property


### PR DESCRIPTION
With this change, Enemies spawn at positions matching tiles in the 'enemies' layer in the tilemap. They will go to the position of the player.

If I choose the position of a random tile in the 'backgrounds' layer, the enemies will often find no path. That is strange, since we make sure none of the tiles in that layer has the same position as any tile in the 'impassables' layer, which is considered impassable when calculating paths.

I would like to hear what @ivan-BRHM has to say about this, since he worked on the _Enemy_ class.
