### PR TITLE
entities remove all but one physics engine on level setup

### DIFF
--- a/my_helpers.py
+++ b/my_helpers.py
@@ -180,6 +180,9 @@ class GameState:
         """
         Position the players on the current maps start positions
         """
+        for e in self.enemies:
+            e.physics_engines = [self.physics_engine]
+
         self.physics_engine.add_sprite_list(
             self.enemies,
             damping=0,
@@ -191,6 +194,9 @@ class GameState:
         """
         Position the players on the current maps start positions
         """
+        for p in self.players:
+            p.physics_engines = [self.physics_engine]
+
         self.physics_engine.add_sprite_list(
             self.players,
             damping=0,

--- a/my_helpers.py
+++ b/my_helpers.py
@@ -180,9 +180,6 @@ class GameState:
         """
         Position the players on the current maps start positions
         """
-        for e in self.enemies:
-            e.physics_engines = [self.physics_engine]
-
         self.physics_engine.add_sprite_list(
             self.enemies,
             damping=0,
@@ -194,6 +191,7 @@ class GameState:
         """
         Position the players on the current maps start positions
         """
+        # prevent accumulation of physics engines from past levels, though we only care about the latest one
         for p in self.players:
             p.physics_engines = [self.physics_engine]
 


### PR DESCRIPTION
this is to prevent the entities from at some point having a lot of physics engine, potentially slowing the game down